### PR TITLE
Added "event_calendar" key

### DIFF
--- a/_data/groups.yml
+++ b/_data/groups.yml
@@ -6,6 +6,7 @@
   acronym: "CSLU"
   url: "https://www.ohsu.edu/xd/research/centers-institutes/center-for-spoken-language-understanding/"
   excerpt: ""
+  event_calendar: "https://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/csee/events.cfm"
 - name: "Department of Biomedical Engineering"
   acronym: "BME"
   url: https://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/biomedical-engineering/research/computational-biology.cfm


### PR DESCRIPTION
OHSU's standard calendaring system has landing pages for each shared calendar; seems like a sensible place to keep that would be in the `groups.yml` config file. Thoughts?